### PR TITLE
feat: add comment widget supports for links page (#183)

### DIFF
--- a/templates/links.html
+++ b/templates/links.html
@@ -34,6 +34,14 @@
           </div>
         </th:block>
       </div>
+      <hr th:if="${haloCommentEnabled}" class="my-10 dark:border-slate-700" />
+      <div th:if="${haloCommentEnabled}">
+          <halo:comment
+              group="plugin.halo.run"
+              kind="Plugin"
+              th:attr="name=${pluginName}"
+          />
+      </div>
     </div>
   </th:block>
 </html>


### PR DESCRIPTION
Fixes https://github.com/halo-dev/theme-earth/issues/182

```release-note
链接页面支持显示评论区
```